### PR TITLE
security-core fixes

### DIFF
--- a/terraform/prod/us-va/regional-vars.tf
+++ b/terraform/prod/us-va/regional-vars.tf
@@ -1,10 +1,10 @@
 provider "azurerm" {
   features {}
 
-  subscription_id            = var.subscription_id
-  tenant_id                  = var.tenant_id
-  environment                = var.az_environment
-  skip_provider_registration = true
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+  environment     = var.az_environment
+  # skip_provider_registration = true # Hashicorp: This property is deprecated and will be removed in v5.0 of the AzureRM provider
 }
 
 variable "location" {

--- a/terraform/prod/us-va/security-core/README.md
+++ b/terraform/prod/us-va/security-core/README.md
@@ -87,7 +87,6 @@ module "core" {
   global_tags             = var.global_tags
   core_rg_name            = "${local.resource_prefix}-core-rg"
   cidrs_for_remote_access = var.cidrs_for_remote_access
-  ip_for_remote_access    = var.ip_for_remote_access
   admin_principal_ids     = var.admin_principal_ids
   enable_diag_logs        = true
   enable_aad_logs         = true

--- a/terraform/prod/us-va/security-core/core.tf
+++ b/terraform/prod/us-va/security-core/core.tf
@@ -11,7 +11,6 @@ module "core" {
   global_tags             = merge(var.global_tags, local.global_local_tags)
   core_rg_name            = "${local.resource_prefix}-core-rg"
   cidrs_for_remote_access = var.cidrs_for_remote_access
-  ip_for_remote_access    = var.ip_for_remote_access
   admin_principal_ids     = var.admin_principal_ids
   app_subscription_ids    = var.app_subscription_ids
   enable_sub_logs         = false

--- a/terraform/prod/us-va/security-core/tstate.tf
+++ b/terraform/prod/us-va/security-core/tstate.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.61.0"
+      version = "~>4.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
1. `ip_for_remote_access` was removed as an input variable on the security-core module. Removed from `module.core` call in `terraform/prod/us-va/security-core/core.tf ` to resolve the following module error: "Error: Unsupported argument... An argument named "ip_for_remote_access" is not expected here."
2. terraform/prod/us-va/security-core/tstate.tf `required_providers.azurerm` threw a version constraint mismatch error; updated to 4.0 to align with azure pak module version constraints
3. removed the deprecated argument `skip_provider_registration` from provider.azurerm in `terraform/prod/us-va/regional-vars.tf` 
4. update `terraform/prod/us-va/security-core/README.md` to remove reference to `ip_for_remote_access`