### PR TITLE
Region-Setup fixes

### DIFF
--- a/terraform/prod/us-va/region-setup/README.md
+++ b/terraform/prod/us-va/region-setup/README.md
@@ -13,21 +13,6 @@ Region setup will provision basic initial resources.
 If this is the first region the settings in `regional-vars.tf` should have been updated with the security-core deployment. If this is an additional region update these variables as appropriate.
 
 - location
-- location_abbreviation# Region Setup Deployment
-
-This is the second terraform folder that is deployed into the environment.
-Region setup will provision basic initial resources.
-
-## Dependencies
-
-- Security Core
-- Sign into the Azure Portal and delete the default NetworkWatcher resource group and resources.
-
-## Code updates
-
-If this is the first region the settings in `regional-vars.tf` should have been updated with the security-core deployment. If this is an additional region update these variables as appropriate.
-
-- location
 - location_abbreviation
 - regional_tags
 
@@ -90,87 +75,7 @@ If you are satisfied with the plan output, run `terraform apply` to deploy.
 
 ## Additional notes
 
-You may need to re-run the apply due to delays in propagation of Key Vault permissions. You should be able to re-run after a few minutes without issues.
-
-After the `mgmt/mgmt-network` is created, uncomment this `firewall_vnet_subnet_ids` argument, and rerun `terraform apply`
-
-## Created Resources
-
-| Resource | Description |
-|------|-------------|
-| Resource Group | Application Plane RG |
-| Resource Group | Key Vault RG |
-| Resource Group | Management Plane |
-| Resource Group | Networking RG|
-| Storage Account | Azure Recovery Services |
-| Storage Account | Cloud Shell |
-| Storage Account | NSG Flow Logs |
-| Storage Account | Install files |
-| Storage Account | VM Diagnostic |
-| Storage Account | FedRamp Documents and Artifacts |
-| Network Watcher | Regional Network Watcher |
-
-## Next steps
-
-Management VNet (terraform/prod/{region}/mgmt/mgmt-network)
-
-- regional_tags
-
-In the `tstate.tf` file update to the appropriate version and storage accounts.  This configures the remote state file with the storage account in Azure.  See sample below:
-
-``` hcl
-terraform {
-  required_version = ">= 1.5.0"
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 3.45.0"
-    }
-  }
-  backend "azurerm" {
-    resource_group_name  = "prod-va-mp-core-rg"
-    storage_account_name = "prodvampsatfstate"
-    container_name       = "vatfstatecontainer"
-    environment          = "usgovernment"
-    key                  = "va-region-setup.tfstate"
-  }
-}
-```
-
-In the `setup.tf` file:
-
-- update the SAS token expiration based on project schedule (if required)
-- update Resource Group names (if required)
-
-## Deployment steps
-
-Sign into the portal and delete the default NetworkWatcher resource group and resources.
-
-Change directory to the `region-setup` folder in the primary region
-
-Run `terraform init` to initialize modules and remote state.
-
-Run `terraform plan` and evaluate the execution plan.
-
-Run `terraform apply` to deploy.
-
-**Note**: you may need to re-run the apply due to delays in propagation of Key Vault permissions. You should be able to re-run after a few minutes without issues.
-
-Update the `remote-data.tf` file to add the region state key.  This pulls down the remote variables from the state file. See sample below:
-
-``` hcl
-data "terraform_remote_state" "setup" {
-  backend = "azurerm"
-
-  config = {
-    storage_account_name = "${local.storage_name_prefix}satfstate"
-    resource_group_name  = "${local.resource_prefix}-core-rg"
-    container_name       = "${var.location_abbreviation}${var.app_abbreviation}tfstatecontainer"
-    environment          = var.az_environment
-    key                  = "${var.location_abbreviation}-region-setup.tfstate"
-  }
-}
-```
+The resources created by `region-setup` are dependent upon the Azure Key Vault permissions created by `security-core`. Since these permissions can take some time to propagate, it is recommended to wait approximately 15-20 minutes after `security-core` is deployed before running `region-setup`. If after waiting, you still encounter errors related to KV permissions, you may wait a few minutes and re-run `terraform apply` in the `region-setup` any number of times until the issue resolves.
 
 After the `mgmt/mgmt-network` is created, uncomment this `firewall_vnet_subnet_ids` argument, and rerun `terraform apply`
 

--- a/terraform/prod/us-va/region-setup/README.md
+++ b/terraform/prod/us-va/region-setup/README.md
@@ -13,7 +13,107 @@ Region setup will provision basic initial resources.
 If this is the first region the settings in `regional-vars.tf` should have been updated with the security-core deployment. If this is an additional region update these variables as appropriate.
 
 - location
+- location_abbreviation# Region Setup Deployment
+
+This is the second terraform folder that is deployed into the environment.
+Region setup will provision basic initial resources.
+
+## Dependencies
+
+- Security Core
+- Sign into the Azure Portal and delete the default NetworkWatcher resource group and resources.
+
+## Code updates
+
+If this is the first region the settings in `regional-vars.tf` should have been updated with the security-core deployment. If this is an additional region update these variables as appropriate.
+
+- location
 - location_abbreviation
+- regional_tags
+
+In the `tstate.tf` file update to the appropriate version and storage accounts.  This configures the remote state file with the storage account in Azure.  See sample below:
+
+``` hcl
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.45.0"
+    }
+  }
+  backend "azurerm" {
+    resource_group_name  = "prod-va-mp-core-rg"
+    storage_account_name = "prodvampsatfstate"
+    container_name       = "vatfstatecontainer"
+    environment          = "usgovernment"
+    key                  = "va-region-setup.tfstate"
+  }
+}
+```
+
+In the `setup.tf` file:
+
+- update the SAS token expiration based on project schedule (if required)
+- update Resource Group names (if required)
+
+## Deployment steps
+
+#### Step 1 - Remove default resources (if applicable)
+Sign into the portal and delete the default NetworkWatcher resource group and resources.
+
+#### Step 2 - Prepare terraform directory
+Change directory to the `region-setup` folder in the primary region
+
+Update the `remote-data.tf` file to add the region state key.  This pulls down the remote variables from the state file. See sample below:
+
+``` hcl
+data "terraform_remote_state" "setup" {
+  backend = "azurerm"
+
+  config = {
+    storage_account_name = "${local.storage_name_prefix}satfstate"
+    resource_group_name  = "${local.resource_prefix}-core-rg"
+    container_name       = "${var.location_abbreviation}${var.app_abbreviation}tfstatecontainer"
+    environment          = var.az_environment
+    key                  = "${var.location_abbreviation}-region-setup.tfstate"
+  }
+}
+```
+
+#### Step 4 - Initialize terraform and apply
+Run `terraform init` to initialize modules and remote state.
+
+Run `terraform plan` and evaluate the execution plan.
+
+If you are satisfied with the plan output, run `terraform apply` to deploy.
+
+## Additional notes
+
+You may need to re-run the apply due to delays in propagation of Key Vault permissions. You should be able to re-run after a few minutes without issues.
+
+After the `mgmt/mgmt-network` is created, uncomment this `firewall_vnet_subnet_ids` argument, and rerun `terraform apply`
+
+## Created Resources
+
+| Resource | Description |
+|------|-------------|
+| Resource Group | Application Plane RG |
+| Resource Group | Key Vault RG |
+| Resource Group | Management Plane |
+| Resource Group | Networking RG|
+| Storage Account | Azure Recovery Services |
+| Storage Account | Cloud Shell |
+| Storage Account | NSG Flow Logs |
+| Storage Account | Install files |
+| Storage Account | VM Diagnostic |
+| Storage Account | FedRamp Documents and Artifacts |
+| Network Watcher | Regional Network Watcher |
+
+## Next steps
+
+Management VNet (terraform/prod/{region}/mgmt/mgmt-network)
+
 - regional_tags
 
 In the `tstate.tf` file update to the appropriate version and storage accounts.  This configures the remote state file with the storage account in Azure.  See sample below:

--- a/terraform/prod/us-va/region-setup/setup.tf
+++ b/terraform/prod/us-va/region-setup/setup.tf
@@ -1,24 +1,21 @@
 module "setup" {
   source = "github.com/Coalfire-CF/ACE-Azure-RegionSetup?ref=v1.0.1"
 
-  subscription_id       = var.subscription_id
   location_abbreviation = var.location_abbreviation
   location              = var.location
   resource_prefix       = local.resource_prefix
   app_abbreviation      = var.app_abbreviation
-  tenant_id             = var.tenant_id
   regional_tags         = var.regional_tags
   global_tags           = merge(var.global_tags, local.global_local_tags)
   mgmt_rg_name          = "${local.resource_prefix}-management-rg"
   app_rg_name           = "${local.resource_prefix}-application-rg"
   key_vault_rg_name     = "${local.resource_prefix}-keyvault-rg"
   networking_rg_name    = "${local.resource_prefix}-networking-rg"
-  sas_start_date        = "2023-09-28" # Today's date
-  sas_end_date          = "2023-12-28" # 3 months from today
+  sas_start_date        = "2025-03-11" # Today's date
+  sas_end_date          = "2025-06-11" # 3 months from today
   ip_for_remote_access  = var.ip_for_remote_access
   core_kv_id            = data.terraform_remote_state.core.outputs.core_kv_id
   diag_log_analytics_id = data.terraform_remote_state.core.outputs.core_la_id
-  admin_principal_ids   = var.admin_principal_ids
 
   # uncomment the following line when the mgmt-network is created
   #firewall_vnet_subnet_ids = values(data.terraform_remote_state.usgv_mgmt_vnet.outputs.usgv_mgmt_vnet_subnet_ids) #Uncomment and rerun terraform apply after the mgmt-network is created

--- a/terraform/prod/us-va/region-setup/setup.tf
+++ b/terraform/prod/us-va/region-setup/setup.tf
@@ -1,5 +1,5 @@
 module "setup" {
-  source = "github.com/Coalfire-CF/ACE-Azure-RegionSetup"
+  source = "github.com/Coalfire-CF/ACE-Azure-RegionSetup?ref=v1.0.1"
 
   subscription_id       = var.subscription_id
   location_abbreviation = var.location_abbreviation

--- a/terraform/prod/us-va/region-setup/tstate.tf
+++ b/terraform/prod/us-va/region-setup/tstate.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~>3.61.0"
+      version = "~>4.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/terraform/prod/us-va/security-core/README.md
+++ b/terraform/prod/us-va/security-core/README.md
@@ -37,7 +37,7 @@ Once the code updates are completed and the `core.tf` file is updated with the a
 
 Once a successful `apply` is completed. You will need to migrate the terraform state from the local one to the remote storage account. This is required to ensure that the state is not lost if the local machine is destroyed and for cross collaboration between engineers.
 
-**NOTE**: If you receive a `Code="ResourceGroupNotFound"` error run `terraform apply` again. 
+**NOTE**: In previous versions of the `security-core` module, `ResourceGroupNotFound` errors would occasionally be encountered when running `terraform apply` for the first time. This behavior was due to a number of resources referencing the Core Resource Group before it was created. ACE-Azure-SecurityCore v1.0.2 introduced dependency fixes which should resolve these errors. However, if you receive a `Code="ResourceGroupNotFound"` error, you may safely invoke `terraform apply` a second time to resolve it. 
 
 Migration steps:
 

--- a/terraform/prod/us-va/security-core/core.tf
+++ b/terraform/prod/us-va/security-core/core.tf
@@ -1,5 +1,5 @@
 module "core" {
-  source = "github.com/Coalfire-CF/ACE-Azure-SecurityCore"
+  source = "github.com/Coalfire-CF/ACE-Azure-SecurityCore?ref=v1.0.2"
 
   subscription_id         = var.subscription_id
   resource_prefix         = local.resource_prefix


### PR DESCRIPTION
Incorporated changes from client build to fix various errors and conflicts:
- updated azurerm version to 4.0 in `terraform/prod/us-va/region-setup/tstate.tf` to eliminate provider constraint conflict
- pinned the `region-setup` module in `terraform/prod/us-va/region-setup/setup.tf` to v1.0.1 to avoid breaking changes in future versions from creeping into the RAMPpak directory
- The following arguments are not supported by the `region-setup` module, and have been removed from `terraform/prod/us-va/region-setup/setup.tf`:
    - subscription_id
    - tenant_id
    - admin_principal_ids
- updated `terraform/prod/us-va/region-setup/README.md` to accurately reflect order of operations, and clarify the key vault permission dependency from `security-core`
- updated `terraform/prod/us-va/security-core/README.md` to reflect changes to security-core v1.0.2