### PR TITLE
Update region-setup to v1.0.7

### DIFF
--- a/terraform/prod/us-va/region-setup/README.md
+++ b/terraform/prod/us-va/region-setup/README.md
@@ -89,14 +89,16 @@ Any number of VM image definitions may be bootstapped in the Azure Compute Galle
       identifier_publisher = "rhel"
       identifier_offer     = "LinuxServer"
       identifier_sku       = "RHEL8-10"
+      hyper_v_generation   = "V2"
     },
     {
       name                 = "win-server2022-golden"
       os_type              = "Windows"
       identifier_publisher = "microsoft"
       identifier_offer     = "WindowsServer"
-      identifier_sku       = "2022-datacenter-g2"
-    }
+      identifier_sku       = "RHEL8-10"
+      hyper_v_generation   = "V2"
+    },
   ]
 }
 ```

--- a/terraform/prod/us-va/region-setup/README.md
+++ b/terraform/prod/us-va/region-setup/README.md
@@ -77,6 +77,38 @@ module "setup" {
 ...
 }
 ```
+### (Optional) Azure Compute Gallery (Image Gallery) Image Definitions
+Any number of VM image definitions may be bootstapped in the Azure Compute Gallery by specifying `vm_image_definitions` as shown in the example below:
+```hcl
+  module "setup" {
+  ...
+  vm_image_definitions = [
+    {
+      name                 = "rhel-8-10-golden-stig"
+      os_type              = "Linux"
+      identifier_publisher = "rhel"
+      identifier_offer     = "LinuxServer"
+      identifier_sku       = "RHEL8-10"
+    },
+    {
+      name                 = "win-server2022-golden"
+      os_type              = "Windows"
+      identifier_publisher = "microsoft"
+      identifier_offer     = "WindowsServer"
+      identifier_sku       = "2022-datacenter-g2"
+    }
+  ]
+}
+```
+
+If `vm_image_definitions` is defined, the module will output a key-value map of all VM image definitions, where the key is the image name and the value is the image ID: 
+```hcl
+# Example Output
+vm_image_definitions = {
+  "rhel-8-10-golden-stig" = "/subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/Microsoft.Compute/galleries/<gallery_name>/images/rhel-8-10-golden-stig"
+  "win-server2022-golden" = "/subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/Microsoft.Compute/galleries/<gallery_name>/images/win-server2022-golden"
+}
+```
 
 ## Deployment steps
 

--- a/terraform/prod/us-va/region-setup/setup.tf
+++ b/terraform/prod/us-va/region-setup/setup.tf
@@ -1,5 +1,5 @@
 module "setup" {
-  source = "github.com/Coalfire-CF/ACE-Azure-RegionSetup?ref=v1.0.6"
+  source = "github.com/Coalfire-CF/ACE-Azure-RegionSetup?ref=v1.0.7"
 
   location_abbreviation = var.location_abbreviation
   location              = var.location
@@ -51,6 +51,7 @@ module "setup" {
   #     identifier_publisher = "rhel"
   #     identifier_offer     = "LinuxServer"
   #     identifier_sku       = "RHEL8-10"
+  #     hyper_v_generation   = "V2"
   #   },
   #   {
   #     name                 = "win-server2022-golden"
@@ -58,6 +59,7 @@ module "setup" {
   #     identifier_publisher = "microsoft"
   #     identifier_offer     = "WindowsServer"
   #     identifier_sku       = "2022-datacenter-g2"
+  #     hyper_v_generation   = "V2"
   #   }
   # ]
 }

--- a/terraform/prod/us-va/region-setup/setup.tf
+++ b/terraform/prod/us-va/region-setup/setup.tf
@@ -1,5 +1,5 @@
 module "setup" {
-  source = "github.com/Coalfire-CF/ACE-Azure-RegionSetup?ref=v1.0.5"
+  source = "github.com/Coalfire-CF/ACE-Azure-RegionSetup?ref=v1.0.6"
 
   location_abbreviation = var.location_abbreviation
   location              = var.location
@@ -23,4 +23,41 @@ module "setup" {
   additional_resource_groups = [
     "${local.resource_prefix}-identity-rg"
   ]
+
+  # (Optional) Resource Names
+  # Uncomment to define custom resource names, if required
+  # compute_gallery_name           = ""
+  # cloudshell_storageaccount_name = ""
+  # ars_storageaccount_name        = ""
+  # docs_storageaccount_name       = ""
+  # flowlogs_storageaccount_name   = ""
+  # installs_storageaccount_name   = ""
+  # vmdiag_storageaccount_name     = ""
+  # network_watcher_name           = ""
+
+  # (Optional) File Uploads
+  # Uncomment to define paths to files which will be uploaded to the installs storage account
+  # file_upload_paths = [
+  #   "../../../../path/to/file",
+  #   "../../../../path/to/another-file"
+  # ]
+
+  # (Optional) VM image definitions 
+  # Uncomment to bootstrap Image Definitions in the Azure Compute Gallery
+  # vm_image_definitions = [
+  #   {
+  #     name                 = "rhel-8-10-golden-stig"
+  #     os_type              = "Linux"
+  #     identifier_publisher = "rhel"
+  #     identifier_offer     = "LinuxServer"
+  #     identifier_sku       = "RHEL8-10"
+  #   },
+  #   {
+  #     name                 = "win-server2022-golden"
+  #     os_type              = "Windows"
+  #     identifier_publisher = "microsoft"
+  #     identifier_offer     = "WindowsServer"
+  #     identifier_sku       = "2022-datacenter-g2"
+  #   }
+  # ]
 }


### PR DESCRIPTION
This update pins the region-setup module to v1.0.7 allowing for VM image definitions to be created as needed. Also updates README.md to document the additional optional argument, as well as adds example configuration to the setup.tf file.